### PR TITLE
Pin dockerfile to 3.13

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:slim
+FROM python:3.13
 
 WORKDIR /app
 


### PR DESCRIPTION
This pull request includes an update to the `Dockerfile` to use a more specific version of Python.

* [`Dockerfile`](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557L1-R1): Changed the base image from `python:slim` to `python:3.13` to ensure compatibility and stability.