### PR TITLE
Fix pre-commit wrangling md.

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,6 +19,7 @@ repos:
     -   id: debug-statements  # check for debugger imports etc.
     -   id: detect-private-key  # detects the presence of private keys
     -   id: trailing-whitespace  # trims trailing whitespace
+        args: ["--markdown-linebreak-ext=md"]
     -   id: name-tests-test
         args: ["--pytest-test-first"]
     -   id: mixed-line-ending  # Check and fix mixed line ending (only LF for compatibility)


### PR DESCRIPTION
This pull request includes a small change to the `.pre-commit-config.yaml` file. The change adds an argument to the `trailing-whitespace` pre-commit hook to specify markdown files for line break extensions.

* [`.pre-commit-config.yaml`](diffhunk://#diff-63a9c44a44acf85fea213a857769990937107cf072831e1a26808cfde9d096b9R22): Added `args: ["--markdown-linebreak-ext=md"]` to the `trailing-whitespace` hook configuration.